### PR TITLE
Web sign out

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,7 @@ repos:
         args: ["--config-file=mypy.ini"]
 
   - repo: https://github.com/psf/black
-    rev: 23.11.0
+    rev: 24.4.2
     hooks:
       - id: black
         args: [--diff, --check]

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -32,8 +32,8 @@ Whether to use httponly cookie for refresh token, defaults to `True`.
 Same-site policy to be used for refresh token cookie, defaults to `"Strict"`.
 
 ### WEB_REFRESH_COOKIE_PATH
-This is the path set on the cookie for refresh token, this path needs to match the url endpoint you are exposing for
-web token refresh. Defaults to `"/api/auth/web/token-refresh"`.
+This is the path set on the cookie for refresh token, this path needs to match the url endpoints you are exposing for
+web token refresh and web sign out. Defaults to `"/api/auth/web"`.
 
 ### USERNAME_FIELD
 This is the field on the User model that is used as the username. Defaults to `"username"`.

--- a/ninja_simple_jwt/auth/views/schemas.py
+++ b/ninja_simple_jwt/auth/views/schemas.py
@@ -21,3 +21,7 @@ class MobileTokenRefreshResponse(Schema):
 
 class WebSignInResponse(Schema):
     access: str
+
+
+class Empty(Schema):
+    pass

--- a/ninja_simple_jwt/settings.py
+++ b/ninja_simple_jwt/settings.py
@@ -36,7 +36,7 @@ DEFAULTS: NinjaSimpleJwtSettingsDict = {
     "WEB_REFRESH_COOKIE_SECURE": not settings.DEBUG,
     "WEB_REFRESH_COOKIE_HTTP_ONLY": True,
     "WEB_REFRESH_COOKIE_SAME_SITE_POLICY": "Strict",
-    "WEB_REFRESH_COOKIE_PATH": "/api/auth/web/token-refresh",
+    "WEB_REFRESH_COOKIE_PATH": "/api/auth/web",
     "USERNAME_FIELD": "username",
     "TOKEN_CLAIM_USER_ATTRIBUTE_MAP": {
         "user_id": "id",

--- a/readme.md
+++ b/readme.md
@@ -187,6 +187,12 @@ curl --location --request POST 'http://127.0.0.1:8000/api/auth/web/token-refresh
 --header 'Cookie: refresh=...'
 ```
 The response would contain an access token in the body.
+- /api/auth/web/sign-out
+```commandline
+curl --location --request POST 'http://127.0.0.1:8000/api/auth/web/sign-out' \
+```
+This will respond with a 204 status code and clear the refresh cookie from client. Note that this does not invalidate
+the token, it only removes the refresh token from the client.
 
 ### Customizing token claims for user
 You can specify a claim on the JWT and what User model attribute to get the claim value from using the


### PR DESCRIPTION
Add web sign out REST API endpoint, fix bugs. This endpoint authenticates using the refresh token in http-only cookie, if successful, removes the token from the same cookie in returned response.