### PR TITLE
Adding of Stateless and Database auth backends

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1,46 +1,69 @@
 # ninja_simple_jwt settings
 
 ### JWT_PRIVATE_KEY_STORAGE
+
 Storage class instance used to store JWT private signing key. Defaults to `"ninja_simple_jwt.jwt.key_store.local_disk_key_storage"`.
 
 ### JWT_PUBLIC_KEY_STORAGE
+
 Storage class instance used to store JWT public verification key. Defaults to `"ninja_simple_jwt.jwt.key_store.local_disk_key_storage"`.
 
 ### JWT_PRIVATE_KEY_PATH
+
 Path to the private key, defaults to `"jwt-signing.pem"`.
 
 ### JWT_PUBLIC_KEY_PATH
+
 Path to the public key, defaults to `"jwt-signing.pub"`.
 
 ### JWT_REFRESH_COOKIE_NAME
+
 Name of the refresh cookie (used only by web auth endpoints), defaults to `"refresh"`.
 
-
 ### JWT_REFRESH_TOKEN_LIFETIME
+
 Defaults to `timedelta(days=30)`.
 
 ### JWT_ACCESS_TOKEN_LIFETIME
+
 Defaults to `timedelta(minutes=15)`
 
 ### WEB_REFRESH_COOKIE_SECURE
+
 Whether to use secure cookie for refresh token, defaults to `not settings.DEBUG`.
 
 ### WEB_REFRESH_COOKIE_HTTP_ONLY
+
 Whether to use httponly cookie for refresh token, defaults to `True`.
 
 ### WEB_REFRESH_COOKIE_SAME_SITE_POLICY
+
 Same-site policy to be used for refresh token cookie, defaults to `"Strict"`.
 
 ### WEB_REFRESH_COOKIE_PATH
+
 This is the path set on the cookie for refresh token, this path needs to match the url endpoints you are exposing for
 web token refresh and web sign out. Defaults to `"/api/auth/web"`.
 
 ### USERNAME_FIELD
+
 This is the field on the User model that is used as the username. Defaults to `"username"`.
 
+### USE_STATELESS_AUTH
+
+Whether to use stateless authentication (default: `True`). When `True`, `HttpJwtAuth` creates a `TokenUser` instance directly from JWT token claims without database lookups. When `False`, it fetches the user from the database using the `user_id` from the token.
+
+Defaults to `True` for better performance and scalability.
+
+### TOKEN_USER_CLS
+
+The TokenUser class used during stateless request handling, instantiated from JWT to represent a User.
+
 ### TOKEN_CLAIM_USER_ATTRIBUTE_MAP
+
 A dictionary mapping token claims to corresponding User model attributes. Defaults to the following which are part
 of Django's default User model:
+
 ```python
 {
     "user_id": "id",
@@ -55,10 +78,12 @@ of Django's default User model:
     "is_active": "is_active",
 }
 ```
+
 If you changed any of these attributes in your Django user model, you will need to update this dictionary accordingly.
 
 See also: [Customizing token claims for user](../readme.md#customizing-token-claims-for-user).
 
 ### TOKEN_USER_ENCODER_CLS
+
 JSON encoder class used to serializing User attributes to JWT claims.
 See [Serializing user attribute into JWT claim](../readme.md#serializing-user-attribute-into-jwt-claim)

--- a/mypy.ini
+++ b/mypy.ini
@@ -27,8 +27,6 @@ plugins =
 
 follow_imports = skip
 
-disable_error_code = "django-manager-missing"
-
 [mypy.plugins.django-stubs]
 django_settings_module = "tests.settings"
 strict_settings = False

--- a/ninja_simple_jwt/auth/ninja_auth.py
+++ b/ninja_simple_jwt/auth/ninja_auth.py
@@ -1,13 +1,20 @@
+from typing import Optional
+
+from django.contrib.auth import get_user_model
 from django.contrib.auth.base_user import AbstractBaseUser
-from django.contrib.auth.models import AnonymousUser
 from django.http import HttpRequest
+from django.utils.module_loading import import_string
 from jwt import PyJWTError
 from ninja.errors import AuthenticationError
 from ninja.security import HttpBearer
 from ninja.security.http import DecodeError
 
+from ninja_simple_jwt.auth.token_user import PrimaryKey, TokenUser
 from ninja_simple_jwt.jwt.token_operations import TokenTypes, decode_token
 from ninja_simple_jwt.settings import ninja_simple_jwt_settings
+
+User = get_user_model()  # type: ignore[assignment]
+TokenUser = import_string(ninja_simple_jwt_settings.TOKEN_USER_CLS)  # type: ignore[assignment,misc]
 
 
 class HttpJwtAuth(HttpBearer):
@@ -15,21 +22,72 @@ class HttpJwtAuth(HttpBearer):
         token = self.decode_authorization(request.headers["Authorization"])
 
         try:
-            access_token = decode_token(token, token_type=TokenTypes.ACCESS, verify=True)
+            # Decode and verify the JWT token
+            decoded_token = decode_token(token, token_type=TokenTypes.ACCESS, verify=True)
+
+            # Extract user_id from the token
+            user_id = decoded_token.get("user_id")
+            if not user_id:
+                raise AuthenticationError("Invalid token: missing user_id")
+
+            user: TokenUser | AbstractBaseUser | None
+            # Authenticate based on configuration
+            if ninja_simple_jwt_settings.USE_STATELESS_AUTH:
+                user = self._create_stateless_user(decoded_token)
+            else:
+                user = self._get_user_from_database(user_id)
+                if user is None:
+                    raise AuthenticationError("Invalid or expired token")
+
+            # Set the authenticated user on the request
+            request.user = user  # type: ignore[assignment]
+
+            return True
+
         except PyJWTError as e:
-            raise AuthenticationError(e)
-
-        self.set_token_claims_to_user(request.user, access_token)
-
-        return True
+            raise AuthenticationError(f"Invalid or expired token: {e}") from e
 
     @staticmethod
-    def set_token_claims_to_user(user: AbstractBaseUser | AnonymousUser, token: dict) -> None:
-        for claim, user_attribute in ninja_simple_jwt_settings.TOKEN_CLAIM_USER_ATTRIBUTE_MAP.items():
-            if isinstance(user_attribute, str):
-                setattr(user, user_attribute, token.get(claim))
-            else:
+    def _create_stateless_user(token: dict) -> TokenUser:
+        """
+        Create a stateless user instance from JWT token claims.
+
+        Args:
+            token: The decoded JWT token payload
+
+        Returns:
+            TokenUser instance populated with token claims
+        """
+        user = TokenUser(
+            user_id=token.get("user_id"),
+            email=token.get("email", None),
+            roles=token.get("roles", []),
+        )
+
+        # Set the primary key attribute on the TokenUser object
+        setattr(user, User._meta.pk.name, token.get("user_id"))  # type: ignore[union-attr]
+
+        # Set all token claims as attributes on the user object
+        for claim in ninja_simple_jwt_settings.TOKEN_CLAIM_USER_ATTRIBUTE_MAP.keys():
+            if claim in token:
                 setattr(user, claim, token.get(claim))
+
+        return user
+
+    @staticmethod
+    def _get_user_from_database(user_id: PrimaryKey) -> Optional[AbstractBaseUser]:
+        """
+        Get user from database using the user_id from token.
+
+        Args:
+            user_id: The user ID from the JWT token (can be int, UUID, str, etc.)
+
+        Returns:
+            User instance if found, None otherwise
+        """
+        # Use the primary key field name dynamically to support any PK type
+        pk_field_name = User._meta.pk.name  # type: ignore[union-attr]
+        return User.objects.filter(**{pk_field_name: user_id}).first()
 
     def decode_authorization(self, value: str) -> str:
         parts = value.split(" ")

--- a/ninja_simple_jwt/auth/token_user.py
+++ b/ninja_simple_jwt/auth/token_user.py
@@ -1,0 +1,121 @@
+from typing import Any, Optional, Union
+from uuid import UUID
+
+from django.contrib.auth import get_user_model
+
+# Type alias for Django primary keys
+# Supports int (most common), UUID objects, and str (for UUID strings from JWT or string PKs)
+PrimaryKey = Union[int, UUID, str]
+
+User = get_user_model()  # type: ignore[assignment]
+
+
+class TokenUser:
+    """
+    Stateless user representation for JWT authentication.
+
+    This class is designed to work with Django ORM queries by providing
+    a pk property and _meta attribute so Django treats it like a model instance.
+    """
+
+    def __init__(self, user_id: PrimaryKey | None = None, email: str | None = None, roles: list[str] | None = None):
+        self.id = user_id
+        self.email = email
+        self.roles = roles or []
+        self.is_authenticated = True
+        # Add _meta attribute so Django's ForeignKey.get_prep_value() recognizes this as model-like
+        # When Django sees hasattr(value, '_meta'), it extracts value.pk instead of passing
+        # the object directly to the field's to_python() method
+        # _meta.model is needed for Django's check_rel_lookup_compatibility()
+        self._meta = type("Meta", (), {"model": User})()
+
+    @property
+    def pk(self) -> PrimaryKey | None:
+        """
+        Primary key property for Django ORM compatibility.
+        This allows TokenUser instances to be used in Django ORM queries like:
+        MyModel.objects.filter(related_user=token_user)
+
+        Works with any primary key type (int, UUID, str, etc.).
+        For UUID primary keys, the value may be a string (from JWT) or UUID object.
+        Django ORM will handle the conversion automatically.
+        """
+        # If id is a UUID string, return it as-is (Django ORM handles string UUIDs)
+        # If it's already a UUID object, return it
+        return self.id
+
+    def __getattribute__(self, name: str) -> Any:
+        """
+        Override attribute access to make TokenUser work with Django's UUIDField.to_python().
+        When Django's UUIDField tries to use the TokenUser object directly (e.g., calling .replace()),
+        we delegate to the string representation of our id.
+        """
+        # First, try normal attribute access
+        try:
+            return super().__getattribute__(name)
+        except AttributeError:
+            # If attribute doesn't exist and it's a string method that Django's UUIDField might call,
+            # delegate to the string representation of our id
+            if name in ("replace", "strip", "lower", "upper", "startswith", "endswith", "split", "find", "index"):
+                id_value = super().__getattribute__("id")
+                if id_value is None:
+                    id_str = ""
+                else:
+                    id_str = str(id_value)
+                return getattr(id_str, name)
+            raise
+
+    def __repr__(self) -> str:
+        """Return a developer-friendly representation for debugging."""
+        return f"TokenUser(id={self.id})"
+
+    def __int__(self) -> int:
+        """Convert to int for compatibility with integer primary keys."""
+        if self.id is None:
+            return 0
+        # Check for UUID objects or UUID strings
+        if isinstance(self.id, UUID) or (isinstance(self.id, str) and self._is_uuid_string(self.id)):
+            raise TypeError("Cannot convert TokenUser with UUID primary key to int. Use .pk or .id instead.")
+        try:
+            return int(self.id)
+        except (ValueError, TypeError) as e:
+            raise TypeError(
+                f"Cannot convert TokenUser with {type(self.id).__name__} primary key to int. Use .pk or .id instead."
+            ) from e
+
+    @staticmethod
+    def _is_uuid_string(value: str) -> bool:
+        """Check if a string is a valid UUID format."""
+        try:
+            UUID(value)
+            return True
+        except (ValueError, AttributeError):
+            return False
+
+    def __str__(self) -> str:
+        """
+        Return string representation of the primary key value.
+        This allows Django ORM to extract the actual ID value when converting to UUID/int/etc.
+        Django's UUIDField.to_python() may call str() on the object, so we need to return the actual ID.
+        """
+        if self.id is None:
+            return ""
+        # Return the string representation of the ID value itself
+        # This allows Django to parse it as UUID/int when used in queries
+        return str(self.id)
+
+    @property
+    def is_anonymous(self) -> bool:
+        return False
+
+    def has_perm(self, perm: str, obj: Optional[object] = None) -> bool:  # pylint: disable=unused-argument
+        # Optional: simple role→permission mapping
+        # For stateless users, permissions are typically handled at the application level
+        return False
+
+    def has_perms(self, perm_list: list[str], obj: Optional[object] = None) -> bool:
+        return all(self.has_perm(p, obj) for p in perm_list)
+
+    def has_module_perms(self, app_label: str) -> bool:  # pylint: disable=unused-argument
+        # For stateless users, module permissions are typically handled at the application level
+        return False

--- a/ninja_simple_jwt/jwt/token_operations.py
+++ b/ninja_simple_jwt/jwt/token_operations.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from datetime import timezone as dt_timezone
 from enum import Enum
 from json import JSONEncoder
 from typing import Any, Optional, Tuple
@@ -88,7 +89,7 @@ def decode_token(token: str, token_type: TokenTypes, verify: bool = True) -> dic
 def _verify_exp(payload: dict) -> None:
     now = timezone.now()
     token_expiry_unix_time = payload["exp"]
-    token_expiry = timezone.make_aware(datetime.fromtimestamp(token_expiry_unix_time))
+    token_expiry = datetime.fromtimestamp(token_expiry_unix_time, tz=dt_timezone.utc)
     if now >= token_expiry:
         raise ExpiredSignatureError("JWT has expired.")
 

--- a/ninja_simple_jwt/settings.py
+++ b/ninja_simple_jwt/settings.py
@@ -21,6 +21,8 @@ class NinjaSimpleJwtSettingsDict(TypedDict):
     WEB_REFRESH_COOKIE_SAME_SITE_POLICY: NotRequired[str]
     WEB_REFRESH_COOKIE_PATH: NotRequired[str]
     USERNAME_FIELD: NotRequired[str]
+    USE_STATELESS_AUTH: NotRequired[bool]
+    TOKEN_USER_CLS: NotRequired[str]
     TOKEN_CLAIM_USER_ATTRIBUTE_MAP: NotRequired[dict[str, str | Callable[[Any], str | int | float | bool | None]]]
     TOKEN_USER_ENCODER_CLS: NotRequired[str]
 
@@ -38,6 +40,8 @@ DEFAULTS: NinjaSimpleJwtSettingsDict = {
     "WEB_REFRESH_COOKIE_SAME_SITE_POLICY": "Strict",
     "WEB_REFRESH_COOKIE_PATH": "/api/auth/web",
     "USERNAME_FIELD": "username",
+    "USE_STATELESS_AUTH": True,
+    "TOKEN_USER_CLS": "ninja_simple_jwt.auth.token_user.TokenUser",
     "TOKEN_CLAIM_USER_ATTRIBUTE_MAP": {
         "user_id": "id",
         "username": "username",
@@ -97,10 +101,10 @@ class NinjaSimpleJwtSettings:
 ninja_simple_jwt_settings = NinjaSimpleJwtSettings(USER_SETTINGS, DEFAULTS)
 
 
-def reload_drf_stripe_settings(*args: Any, **kwargs: Any) -> None:
+def reload_ninja_simple_jwt_settings(*args: Any, **kwargs: Any) -> None:
     setting = kwargs["setting"]
     if setting == "NINJA_SIMPLE_JWT":
         ninja_simple_jwt_settings.reload()
 
 
-setting_changed.connect(reload_drf_stripe_settings)
+setting_changed.connect(reload_ninja_simple_jwt_settings)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ load-plugins = "pylint_django"
 django-settings-module = "tests.settings"
 max-parents = 15
 max-attributes=12
+ignore = ["setup.py"]
 
 [tool.pylint.messages_control]
 

--- a/readme.md
+++ b/readme.md
@@ -5,10 +5,13 @@ Provides simple JWT based stateless authentication for Django-ninja
 ## Quick start
 
 Install package:
+
 ```commandline
 pip install django-ninja-simple-jwt
 ```
+
 add `ninja_simple_jwt` to list of `INSTALLED_APPS` in Django settings:
+
 ```python
 # settings.py
 
@@ -18,7 +21,19 @@ INSTALLED_APPS = [
 ]
 ```
 
+(Optional) Configure authentication mode. By default, `HttpJwtAuth` uses stateless authentication:
+
+```python
+# settings.py
+
+NINJA_SIMPLE_JWT = {
+    "USE_STATELESS_AUTH": True,  # Default: True - creates TokenUser from JWT claims
+    # Set to False to fetch users from database instead
+}
+```
+
 Expose `Django-ninja`'s API and add `ninja_simple_jwt`'s auth API endpoint router to the API, ie:
+
 ```python
 # urls.py
 
@@ -32,7 +47,9 @@ api.add_router("/auth/web/", web_auth_router)
 
 urlpatterns = [path("api/", api.urls)]
 ```
+
 This would provide 4 available auth API endpoints for mobile and web sign in and token refresh:
+
 - {{server_url}}/api/auth/mobile/sign-in
 - {{server_url}}/api/auth/mobile/token-refresh
 - {{server_url}}/api/auth/web/sign-in
@@ -42,6 +59,7 @@ _If you are not exposing the API and routers at the exact path as the example ab
 see [`WEB_REFRESH_COOKIE_PATH`](docs/settings.md#webrefreshcookiepath) setting regarding web auth token refresh path._
 
 To protect a resource API, you can use the `HttpJwtAuth` as the auth argument when instantiating a Router, ie:
+
 ```python
 # views.py
 
@@ -56,17 +74,42 @@ def hello(request):
 ```
 
 Finally, before starting up the server, create a key pair to be used by the server for signing and verifying JWT:
+
 ```commandline
 python manage.py make_rsa
 ```
-You should see two files created in the root of project repository:
-- jwt-signing.pem  # this is the private key used to sign a JWT, keep this secret, store appropriately
-- jwt-signing.pub  # this is the public key used to verify a JWT
 
+You should see two files created in the root of project repository:
+
+- jwt-signing.pem # this is the private key used to sign a JWT, keep this secret, store appropriately
+- jwt-signing.pub # this is the public key used to verify a JWT
 
 ## Documentation
 
+### Stateless authentication
+
+By default, `HttpJwtAuth` uses stateless authentication, creating a `TokenUser` instance directly from JWT token claims without requiring database lookups. This provides better performance and scalability.
+
+To use stateless authentication (default):
+
+```python
+# settings.py
+NINJA_SIMPLE_JWT = {
+    "USE_STATELESS_AUTH": True,  # Default
+}
+```
+
+To use database-backed authentication (fetches user from database):
+
+```python
+# settings.py
+NINJA_SIMPLE_JWT = {
+    "USE_STATELESS_AUTH": False,
+}
+```
+
 ### Customizing JWT key storage
+
 By default, the management command `make_rsa` will create and store the JWT key pairs in the root of your project
 directory, this is only intended for development.
 
@@ -81,7 +124,9 @@ from storages.backends.s3boto3 import S3Boto3Storage
 aws_s3_private_key_storage = S3Boto3Storage(bucket_name="MySecretJwtKeysStorage")
 aws_s3_public_key_storage = S3Boto3Storage(bucket_name="MyPublicJwtKeysStorage")
 ```
+
 and provide the above storage instances in Django settings:
+
 ```python
 # settings.py
 
@@ -91,16 +136,18 @@ NINJA_SIMPLE_JWT = {
     ...
 }
 ```
+
 You can provide any custom storage implementation in this setting provided that they follow Django's Storage API.
 
 _You should make sure that the private key storage is only accessible by the auth service application.
 The public key storage may be made accessible by other services that need to verify the JWT issued by the auth service._
 
-
 ### Enabling auth API endpoints
 
 #### Mobile
+
 You can enable the mobile auth end points by adding a provided router to the ninja API class:
+
 ```python
 # urls.py
 
@@ -114,7 +161,9 @@ api.add_router("/auth/mobile/", mobile_auth_router)
 
 urlpatterns = [path("api/", api.urls)]
 ```
+
 In the above example with the `mobile_auth_router`, you would gain the following endpoints:
+
 - /api/auth/mobile/sign-in
 
 ```commandline
@@ -125,11 +174,13 @@ curl --location 'http://127.0.0.1:8000/api/auth/mobile/sign-in' \
     "password": "my-password"
 }'
 ```
+
 The response would contain refresh and access JWT in the body:
+
 ```json
 {
-    "refresh": "...",
-    "access": "..."
+  "refresh": "...",
+  "access": "..."
 }
 ```
 
@@ -142,7 +193,9 @@ curl --location 'http://127.0.0.1:8000/api/auth/mobile/token-refresh' \
     "refresh": "..."
 }'
 ```
+
 The response would contain an access JWT in the body:
+
 ```json
 {
   "access": "..."
@@ -150,10 +203,12 @@ The response would contain an access JWT in the body:
 ```
 
 #### Web
+
 _See also: [web auth endpoint design](docs/auth_api_design.md#why-are-the-web-endpoints-designed-to-handle-access-and-refresh-tokens-like-this)._
 
 Similarly to the Mobile auth end point example above,
 you can enable the web auth endpoints by adding it to the ninja API class:
+
 ```python
 # urls.py
 
@@ -166,8 +221,11 @@ api.add_router("/auth/web/", web_auth_router)
 
 urlpatterns = [path("api/", api.urls)]
 ```
+
 You would gain the following endpoints:
+
 - /api/auth/web/sign-in
+
 ```commandline
 curl --location 'http://127.0.0.1:8000/api/auth/web/sign-in' \
 --header 'Content-Type: application/json' \
@@ -176,28 +234,39 @@ curl --location 'http://127.0.0.1:8000/api/auth/web/sign-in' \
     "password": "my-password"
 }'
 ```
+
 The response would contain the access JWT in the body, however the refresh JWT is only in a cookie:
+
 ```
 refresh=...; expires=Fri, 09 Feb 2024 03:49:33 GMT; HttpOnly; Max-Age=2591999; Path=/api/auth/web/token-refresh; SameSite=Strict
 ```
+
 By default, this refresh cookie is only used when calling the token refresh endpoint (below).
+
 - /api/auth/web/token-refresh
+
 ```commandline
 curl --location --request POST 'http://127.0.0.1:8000/api/auth/web/token-refresh' \
 --header 'Cookie: refresh=...'
 ```
+
 The response would contain an access token in the body.
+
 - /api/auth/web/sign-out
+
 ```commandline
 curl --location --request POST 'http://127.0.0.1:8000/api/auth/web/sign-out' \
 ```
+
 This will respond with a 204 status code and clear the refresh cookie from client. Note that this does not invalidate
 the token, it only removes the refresh token from the client.
 
 ### Customizing token claims for user
+
 You can specify a claim on the JWT and what User model attribute to get the claim value from using the
 setting `TOKEN_CLAIM_USER_ATTRIBUTE_MAP`.
 By default, this setting has the following value:
+
 ```python
 {
     # claim: model attribute
@@ -206,15 +275,20 @@ By default, this setting has the following value:
     "last_login": "last_login",
 }
 ```
+
 The mapping can also take a function as the value, ie:
+
 ```python
 {
     "full_name": lambda user: user.first_name + " " + user.last_name,
 }
 ```
+
 #### Serializing user attribute into JWT claim
+
 If the model attribute is not by default serializeable, you can specify how to serialize it by providing a custom
 implementation of json encoder class. Ie:
+
 ```python
 # some_directory/custom_encoders.py
 
@@ -231,7 +305,9 @@ class CustomTokenUserEncoder(TokenUserEncoder):
         # custom serialization implementation here
         return "serialized value"
 ```
+
 And then provide the import string for this class in Django setting:
+
 ```python
 # settings.py
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 
 black==24.4.2
-cryptography==43.0.0
+cryptography==44.0.1
 Django>=4.2
 django-ninja>=1.0
 django-stubs[compatible-mypy]==4.2.7
-freezegun==1.2.2
+freezegun>=1.5.0
 isort==5.12.0
 mypy>=1.7
 pre-commit==3.4.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-ninja-simple-jwt
-version = 0.6.1
+version = 0.7.0
 description = Simple JWT-based authentication using Django and Django-ninja
 long_description = file: README.md
 url = https://github.com/oscarychen/django-ninja-simple-jwt
@@ -31,7 +31,7 @@ include_package_data = true
 packages = find:
 python_requires = >=3.10
 install_requires =
-    cryptography>=41.0
+    cryptography>=44.0.1
     Django >= 4.0
     django-ninja >= 1.0
     pyjwt >= 2.6

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import find_packages, setup
+from setuptools import find_packages, setup  # pylint: disable=import-error,E0401
 
 setup(
     long_description_content_type="text/markdown",

--- a/tests/test_auth/test_api.py
+++ b/tests/test_auth/test_api.py
@@ -52,6 +52,37 @@ class TestMobileSignIn(TestAuthEndPoints):
 
         self.assertEqual(401, response.status_code, "Inactive user cannot sign in.")
 
+    def test_invalid_credentials_returns_401(self) -> None:
+        username = "user"
+        password = "password"
+        get_user_model().objects.create_user(username=username, password=password)
+
+        response = self.client.post(
+            reverse("api-1.0.0:mobile_signin"),
+            data={"username": username, "password": "wrong_password"},
+            content_type="application/json",
+        )
+
+        self.assertEqual(401, response.status_code, "Invalid credentials return 401.")
+
+    def test_missing_username_returns_422(self) -> None:
+        response = self.client.post(
+            reverse("api-1.0.0:mobile_signin"),
+            data={"password": "password"},
+            content_type="application/json",
+        )
+
+        self.assertEqual(422, response.status_code, "Missing username returns 422.")
+
+    def test_missing_password_returns_422(self) -> None:
+        response = self.client.post(
+            reverse("api-1.0.0:mobile_signin"),
+            data={"username": "user"},
+            content_type="application/json",
+        )
+
+        self.assertEqual(422, response.status_code, "Missing password returns 422.")
+
 
 class TestMobileRefresh(TestAuthEndPoints):
     def test_user_can_refresh_token(self) -> None:
@@ -74,6 +105,47 @@ class TestMobileRefresh(TestAuthEndPoints):
         self.assertEqual(200, response.status_code, "Correct status code.")
         self.assertIn("access", response.json(), "Response data contains access token.")
         self.assertNotIn("refresh", response.json(), "Response data should not contain refresh token.")
+
+    def test_invalid_refresh_token_returns_401(self) -> None:
+        response = self.client.post(
+            reverse("api-1.0.0:mobile_token_refresh"),
+            data={"refresh": "invalid_token"},
+            content_type="application/json",
+        )
+
+        self.assertEqual(401, response.status_code, "Invalid refresh token returns 401.")
+
+    def test_expired_refresh_token_returns_401(self) -> None:
+        user = get_user_model().objects.create_user(username="user")
+
+        with self.settings(
+            NINJA_SIMPLE_JWT=self.merge_settings(
+                JWT_REFRESH_TOKEN_LIFETIME=timedelta(days=31),
+                JWT_ACCESS_TOKEN_LIFETIME=timedelta(minutes=5),
+            )
+        ):
+            # Create token in the past
+            with freeze_time("2024-01-11 12:00:01"):
+                refresh_token, _ = get_refresh_token_for_user(user)
+
+            # Try to use it after expiration
+            with freeze_time("2024-03-11 12:00:01"):
+                response = self.client.post(
+                    reverse("api-1.0.0:mobile_token_refresh"),
+                    data={"refresh": refresh_token},
+                    content_type="application/json",
+                )
+
+        self.assertEqual(401, response.status_code, "Expired refresh token returns 401.")
+
+    def test_missing_refresh_token_returns_422(self) -> None:
+        response = self.client.post(
+            reverse("api-1.0.0:mobile_token_refresh"),
+            data={},
+            content_type="application/json",
+        )
+
+        self.assertEqual(422, response.status_code, "Missing refresh token returns 422.")
 
 
 class TestWebSignIn(TestAuthEndPoints):
@@ -125,6 +197,20 @@ class TestWebSignIn(TestAuthEndPoints):
 
         self.assertEqual(401, response.status_code, "Inactive user cannot sign in.")
 
+    def test_invalid_credentials_returns_401(self) -> None:
+        username = "user"
+        password = "password"
+        get_user_model().objects.create_user(username=username, password=password)
+
+        response = self.client.post(
+            reverse("api-1.0.0:web_signin"),
+            data={"username": username, "password": "wrong_password"},
+            content_type="application/json",
+        )
+
+        self.assertEqual(401, response.status_code, "Invalid credentials return 401.")
+        self.assertNotIn("refresh", response.cookies, "No refresh cookie set on failed login.")
+
 
 class TestWebRefresh(TestAuthEndPoints):
     def test_user_token_refresh_valid(self) -> None:
@@ -151,7 +237,6 @@ class TestWebRefresh(TestAuthEndPoints):
         self.assertNotIn("refresh", response.json(), "Response body should not have refresh token.")
 
     def test_user_token_refresh_invalid(self) -> None:
-
         with self.settings(
             NINJA_SIMPLE_JWT=self.merge_settings(
                 JWT_REFRESH_TOKEN_LIFETIME=timedelta(days=31),
@@ -169,6 +254,38 @@ class TestWebRefresh(TestAuthEndPoints):
         self.assertEqual(401, response.status_code, "Correct status code.")
         self.assertNotIn("access", response.json(), "Response body does not have access token.")
         self.assertNotIn("refresh", response.json(), "Response body does not have refresh token.")
+
+    def test_missing_cookie_returns_401(self) -> None:
+        response = self.client.post(
+            reverse("api-1.0.0:web_token_refresh"),
+            content_type="application/json",
+        )
+
+        self.assertEqual(401, response.status_code, "Missing cookie returns 401.")
+
+    def test_expired_refresh_token_returns_401(self) -> None:
+        user = get_user_model().objects.create_user(username="user")
+
+        with self.settings(
+            NINJA_SIMPLE_JWT=self.merge_settings(
+                JWT_REFRESH_TOKEN_LIFETIME=timedelta(days=31),
+                JWT_ACCESS_TOKEN_LIFETIME=timedelta(minutes=5),
+                JWT_REFRESH_COOKIE_NAME="refresh-token",
+            )
+        ):
+            # Create token in the past
+            with freeze_time("2024-01-11 12:00:01"):
+                refresh_token, _ = get_refresh_token_for_user(user)
+
+            # Try to use it after expiration
+            with freeze_time("2024-03-11 12:00:01"):
+                response = self.client.post(
+                    reverse("api-1.0.0:web_token_refresh"),
+                    content_type="application/json",
+                    HTTP_COOKIE=f"refresh-token={refresh_token}",
+                )
+
+        self.assertEqual(401, response.status_code, "Expired refresh token returns 401.")
 
 
 class TestWebSignOut(TestAuthEndPoints):
@@ -197,7 +314,6 @@ class TestWebSignOut(TestAuthEndPoints):
         )
 
     def test_user_sign_out_with_invalid_refresh_token(self) -> None:
-
         with self.settings(
             NINJA_SIMPLE_JWT=self.merge_settings(
                 JWT_REFRESH_COOKIE_NAME="refresh-token",
@@ -212,3 +328,27 @@ class TestWebSignOut(TestAuthEndPoints):
 
         self.assertEqual(401, response.status_code, "Correct status code.")
         self.assertNotIn("refresh-token", response.cookies, "Response header Set-Cookie does not has refresh token.")
+
+    def test_user_sign_out_without_cookie_returns_401(self) -> None:
+        response = self.client.post(
+            reverse("api-1.0.0:web_sign_out"),
+            content_type="application/json",
+        )
+
+        self.assertEqual(401, response.status_code, "Missing cookie returns 401.")
+
+    def test_cookie_is_deleted_with_default_path(self) -> None:
+        """Test that cookie is deleted with the default path setting."""
+        user = get_user_model().objects.create_user(username="user")
+
+        refresh_token, _ = get_refresh_token_for_user(user)
+        response = self.client.post(
+            reverse("api-1.0.0:web_sign_out"),
+            content_type="application/json",
+            HTTP_COOKIE=f"refresh={refresh_token}",
+        )
+
+        self.assertEqual(204, response.status_code, "Correct status code.")
+        refresh_token_cookie = response.cookies.get("refresh")
+        self.assertIsNotNone(refresh_token_cookie, "Refresh cookie present in response.")
+        self.assertEqual("/api/auth/web", refresh_token_cookie["path"], "Cookie deleted with default path.")

--- a/tests/test_auth/test_ninja_auth.py
+++ b/tests/test_auth/test_ninja_auth.py
@@ -1,10 +1,19 @@
+from datetime import timedelta
 from typing import Any
+from unittest.mock import MagicMock
 
+from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
+from django.http import HttpRequest
 from django.test import TestCase
+from django.utils.dateparse import parse_datetime
+from freezegun import freeze_time
+from ninja.errors import AuthenticationError
+from ninja.security.http import DecodeError
 
 from ninja_simple_jwt.auth.ninja_auth import HttpJwtAuth
 from ninja_simple_jwt.jwt.key_creation import make_and_save_key_pair
+from ninja_simple_jwt.jwt.token_operations import get_access_token_for_user
 from ninja_simple_jwt.settings import DEFAULTS
 
 
@@ -15,25 +24,284 @@ class TestNinjaAuth(TestCase):
 
     def setUp(self) -> None:
         make_and_save_key_pair()
+        self.user = get_user_model().objects.create_user(username="testuser", password="testpass")
+        self.auth = HttpJwtAuth()
 
-
-class TestHttpJwtAuth(TestNinjaAuth):
-    def test_set_string_token_claims_to_user(self) -> None:
-        username = "user"
-        token_data = {"username": username}
-        user = AnonymousUser()
+    def test_authenticate_with_valid_token(self) -> None:
+        """Test authentication with a valid JWT token."""
         with self.settings(
-            NINJA_SIMPLE_JWT=self.merge_settings(TOKEN_CLAIM_USER_ATTRIBUTE_MAP={"username": "username"})
+            NINJA_SIMPLE_JWT=self.merge_settings(
+                JWT_ACCESS_TOKEN_LIFETIME=timedelta(minutes=5),
+                TOKEN_CLAIM_USER_ATTRIBUTE_MAP={
+                    "user_id": "id",
+                    "username": "username",
+                },
+            )
         ):
-            HttpJwtAuth.set_token_claims_to_user(user, token_data)
-            self.assertEqual(user.username, username, "Default settings should set the token claims to the user.")
+            with freeze_time("2024-01-11 12:00:01"):
+                token, _ = get_access_token_for_user(self.user)
 
-    def test_set_customized_callable_token_claims_to_user(self) -> None:
-        username = "user"
-        token_data = {"username": username}
-        user = AnonymousUser()
+                # Create mock request
+                request = MagicMock(spec=HttpRequest)
+                request.headers = {"Authorization": f"Bearer {token}"}
+                request.user = AnonymousUser()
+
+                # Authenticate
+                result = self.auth.authenticate(request, token)
+
+                self.assertTrue(result, "Authentication should return True")
+                self.assertIsNotNone(request.user, "User should be set on request")
+                self.assertEqual(request.user.id, self.user.id, "User ID should match")
+                self.assertEqual(request.user.username, self.user.username, "Username should match")
+
+    def test_authenticate_with_invalid_token(self) -> None:
+        """Test authentication with an invalid JWT token."""
+        request = MagicMock(spec=HttpRequest)
+        request.headers = {"Authorization": "Bearer invalid_token"}
+        request.user = AnonymousUser()
+
+        with self.assertRaises(AuthenticationError):
+            self.auth.authenticate(request, "invalid_token")
+
+    def test_authenticate_with_expired_token(self) -> None:
+        """Test authentication with an expired JWT token."""
         with self.settings(
-            NINJA_SIMPLE_JWT=self.merge_settings(TOKEN_CLAIM_USER_ATTRIBUTE_MAP={"username": lambda u: "foo"})
+            NINJA_SIMPLE_JWT=self.merge_settings(
+                JWT_ACCESS_TOKEN_LIFETIME=timedelta(minutes=5),
+                TOKEN_CLAIM_USER_ATTRIBUTE_MAP={
+                    "user_id": "id",
+                    "username": "username",
+                },
+            )
         ):
-            HttpJwtAuth.set_token_claims_to_user(user, token_data)
-            self.assertEqual(user.username, username, "Customized settings should set the token claims to the user.")
+            # Create token in the past
+            with freeze_time("2024-01-11 12:00:01"):
+                token, _ = get_access_token_for_user(self.user)
+
+            # Try to use it after expiration
+            with freeze_time("2024-01-11 12:10:01"):
+                request = MagicMock(spec=HttpRequest)
+                request.headers = {"Authorization": f"Bearer {token}"}
+                request.user = AnonymousUser()
+
+                with self.assertRaises(AuthenticationError):
+                    self.auth.authenticate(request, token)
+
+    def test_decode_authorization_valid_header(self) -> None:
+        """Test decoding a valid Authorization header."""
+        token = self.auth.decode_authorization("Bearer test_token_123")
+        self.assertEqual(token, "test_token_123", "Token should be extracted correctly")
+
+    def test_decode_authorization_invalid_format(self) -> None:
+        """Test decoding an invalid Authorization header format."""
+        with self.assertRaises(DecodeError) as context:
+            self.auth.decode_authorization("test_token_123")
+
+        self.assertIn("Invalid Authorization header", str(context.exception))
+
+    def test_decode_authorization_wrong_scheme(self) -> None:
+        """Test decoding an Authorization header with wrong scheme."""
+        with self.assertRaises(DecodeError) as context:
+            self.auth.decode_authorization("Basic test_token_123")
+
+        self.assertIn("Invalid Authorization header", str(context.exception))
+
+    def test_decode_authorization_case_insensitive(self) -> None:
+        """Test that Bearer scheme is case-insensitive."""
+        token = self.auth.decode_authorization("bearer test_token_123")
+        self.assertEqual(token, "test_token_123", "Should accept lowercase 'bearer'")
+
+        token = self.auth.decode_authorization("BEARER test_token_123")
+        self.assertEqual(token, "test_token_123", "Should accept uppercase 'BEARER'")
+
+    def test_authenticate_with_stateless_user(self) -> None:
+        """Test that authentication works with stateless user creation (no DB lookup)."""
+        with self.settings(
+            NINJA_SIMPLE_JWT=self.merge_settings(
+                JWT_ACCESS_TOKEN_LIFETIME=timedelta(minutes=5),
+                TOKEN_CLAIM_USER_ATTRIBUTE_MAP={
+                    "user_id": "id",
+                    "username": "username",
+                },
+            )
+        ):
+            with freeze_time("2024-01-11 12:00:01"):
+                token, _ = get_access_token_for_user(self.user)
+                user_id = self.user.id
+                username = self.user.username
+
+                # Delete the user to prove we're not fetching from DB
+                self.user.delete()
+
+                request = MagicMock(spec=HttpRequest)
+                request.headers = {"Authorization": f"Bearer {token}"}
+                request.user = AnonymousUser()
+
+                # Authenticate should still work because we create user from token claims
+                result = self.auth.authenticate(request, token)
+
+                self.assertTrue(result, "Authentication should return True")
+                self.assertIsNotNone(request.user, "User should be set on request")
+                self.assertEqual(request.user.id, user_id, "User ID should match token claim")
+                self.assertEqual(request.user.username, username, "Username should match token claim")
+
+
+class TestHttpJwtAuthWithDatabaseBackend(TestCase):
+    """Test HttpJwtAuth with USE_STATELESS_AUTH=False (database-backed authentication)."""
+
+    @staticmethod
+    def merge_settings(**kwargs: Any) -> dict:
+        return {**DEFAULTS, **kwargs}
+
+    def setUp(self) -> None:
+        make_and_save_key_pair()
+        self.user = get_user_model().objects.create_user(username="testuser2", password="testpass2")
+
+    def test_authenticate_with_valid_token_and_database_backend(self) -> None:
+        """Test authentication with a valid JWT token using database-backed mode."""
+        with self.settings(
+            NINJA_SIMPLE_JWT=self.merge_settings(
+                USE_STATELESS_AUTH=False,
+            )
+        ):
+            with freeze_time("2024-01-11 12:00:01"):
+                token, _ = get_access_token_for_user(self.user)
+                request = MagicMock(spec=HttpRequest)
+                request.headers = {"Authorization": f"Bearer {token}"}
+                request.user = AnonymousUser()
+
+                auth = HttpJwtAuth()
+                result = auth.authenticate(request, token)
+
+            self.assertTrue(result, "Authentication should return True")
+            self.assertIsNotNone(request.user, "User should be set on request")
+            self.assertEqual(request.user.id, self.user.id, "User ID should match")
+            self.assertEqual(request.user.username, self.user.username, "Username should match")
+
+    def test_authenticate_with_invalid_token_and_database_backend(self) -> None:
+        """Test authentication with an invalid JWT token using database-backed mode."""
+        with self.settings(
+            NINJA_SIMPLE_JWT=self.merge_settings(
+                USE_STATELESS_AUTH=False,
+            )
+        ):
+            request = MagicMock(spec=HttpRequest)
+            request.headers = {"Authorization": "Bearer invalid_token"}
+            request.user = AnonymousUser()
+
+            auth = HttpJwtAuth()
+            with self.assertRaises(AuthenticationError):
+                auth.authenticate(request, "invalid_token")
+
+    def test_authenticate_with_expired_token_and_database_backend(self) -> None:
+        """Test authentication with an expired JWT token using database-backed mode."""
+        with self.settings(
+            NINJA_SIMPLE_JWT=self.merge_settings(
+                USE_STATELESS_AUTH=False,
+                JWT_ACCESS_TOKEN_LIFETIME=timedelta(minutes=5),
+            )
+        ):
+            with freeze_time("2024-01-11 12:00:01"):
+                token, _ = get_access_token_for_user(self.user)
+
+            with freeze_time("2024-01-11 12:10:01"):
+                request = MagicMock(spec=HttpRequest)
+                request.headers = {"Authorization": f"Bearer {token}"}
+                request.user = AnonymousUser()
+
+                auth = HttpJwtAuth()
+                with self.assertRaises(AuthenticationError):
+                    auth.authenticate(request, token)
+
+
+class TestHttpJwtAuthWithStatelessBackend(TestCase):
+    """Test HttpJwtAuth with USE_STATELESS_AUTH=True (stateless authentication)."""
+
+    @staticmethod
+    def merge_settings(**kwargs: Any) -> dict:
+        return {**DEFAULTS, **kwargs}
+
+    def setUp(self) -> None:
+        make_and_save_key_pair()
+        self.user = get_user_model().objects.create_user(username="testuser3", password="testpass3")
+
+    def test_authenticate_with_valid_token_and_stateless_backend(self) -> None:
+        """Test authentication with a valid JWT token using stateless mode."""
+        with self.settings(
+            NINJA_SIMPLE_JWT=self.merge_settings(
+                USE_STATELESS_AUTH=True,
+            )
+        ):
+            with freeze_time("2024-01-11 12:00:01"):
+                token, _ = get_access_token_for_user(self.user)
+                request = MagicMock(spec=HttpRequest)
+                request.headers = {"Authorization": f"Bearer {token}"}
+                request.user = AnonymousUser()
+
+                auth = HttpJwtAuth()
+                result = auth.authenticate(request, token)
+
+            self.assertTrue(result, "Authentication should return True")
+            self.assertIsNotNone(request.user, "User should be set on request")
+            self.assertEqual(request.user.id, self.user.id, "User ID should match")
+            self.assertEqual(request.user.username, self.user.username, "Username should match")
+            # After authentication, request.user is a TokenUser, not AnonymousUser
+            self.assertEqual(request.user.email, self.user.email, "Email should match")  # pylint: disable=no-member
+            self.assertEqual(request.user.is_staff, self.user.is_staff, "Is staff should match")
+            self.assertEqual(request.user.is_superuser, self.user.is_superuser, "Is superuser should match")
+            self.assertEqual(request.user.is_active, self.user.is_active, "Is active should match")
+            # For datetime fields, parse the JWT string and compare with original datetime
+            # Note: JWT serialization may lose microsecond precision, so we compare up to seconds
+            if self.user.last_login and request.user.last_login:  # pylint: disable=no-member
+                parsed_last_login = parse_datetime(request.user.last_login)  # pylint: disable=no-member
+                if parsed_last_login and self.user.last_login:
+                    # Compare up to seconds precision (ignore microseconds)
+                    self.assertEqual(
+                        parsed_last_login.replace(microsecond=0),
+                        self.user.last_login.replace(microsecond=0),
+                        "Last login should match",
+                    )
+            if self.user.date_joined and request.user.date_joined:  # pylint: disable=no-member
+                parsed_date_joined = parse_datetime(request.user.date_joined)  # pylint: disable=no-member
+                if parsed_date_joined and self.user.date_joined:
+                    # Compare up to seconds precision (ignore microseconds)
+                    self.assertEqual(
+                        parsed_date_joined.replace(microsecond=0),
+                        self.user.date_joined.replace(microsecond=0),
+                        "Date joined should match",
+                    )
+
+    def test_authenticate_with_invalid_token_and_stateless_backend(self) -> None:
+        """Test authentication with an invalid JWT token using stateless mode."""
+        with self.settings(
+            NINJA_SIMPLE_JWT=self.merge_settings(
+                USE_STATELESS_AUTH=True,
+            )
+        ):
+            request = MagicMock(spec=HttpRequest)
+            request.headers = {"Authorization": "Bearer invalid_token"}
+            request.user = AnonymousUser()
+
+            auth = HttpJwtAuth()
+            with self.assertRaises(AuthenticationError):
+                auth.authenticate(request, "invalid_token")
+
+    def test_authenticate_with_expired_token_and_stateless_backend(self) -> None:
+        """Test authentication with an expired JWT token using stateless mode."""
+        with self.settings(
+            NINJA_SIMPLE_JWT=self.merge_settings(
+                USE_STATELESS_AUTH=True,
+                JWT_ACCESS_TOKEN_LIFETIME=timedelta(minutes=5),
+            )
+        ):
+            with freeze_time("2024-01-11 12:00:01"):
+                token, _ = get_access_token_for_user(self.user)
+
+            with freeze_time("2024-01-11 12:10:01"):
+                request = MagicMock(spec=HttpRequest)
+                request.headers = {"Authorization": f"Bearer {token}"}
+                request.user = AnonymousUser()
+
+                auth = HttpJwtAuth()
+                with self.assertRaises(AuthenticationError):
+                    auth.authenticate(request, token)

--- a/tox.ini
+++ b/tox.ini
@@ -1,26 +1,24 @@
 [tox]
 envlist =
-    lint-py{312}
-    dj{42,50,51}-py{310,311,312}
+    lint-py{312,313,314}
+    dj{42,52}-py{312,313,314}
 
 skip_missing_interpreters =
     true
 
 [gh-actions]
 python =
-    3.10: py310
-    3.11: py311
     3.12: py312
+    3.13: py313
+    3.14: py314
 DJANGO=
     4.2: dj42
-    5.0: dj50
-
+    5.2: dj52
 [testenv]
 deps =
     {[base]deps}
     dj42: Django>=4.2,<5.0
-    dj50: Django>=5.0,<5.1
-    dj51: Django>=5.1,<6.0
+    dj52: Django>=5.2,<6.0
 commands = python -m django test
 setenv =
     DJANGO_SETTINGS_MODULE = tests.settings


### PR DESCRIPTION
Follow up to conversation on [previous PR](https://github.com/oscarychen/django-ninja-simple-jwt/pull/24): 

Currently, [django-ninja-simple-jwt](https://github.com/oscarychen/django-ninja-simple-jwt) authenticates statelessly using JWT token, the authenticated request in Django will have an `AnonymousUser` instance but with custom user attributes made available from the JWT token claims. This required some consideration in writing the queries inside the application, ie:
```python
SomeModel.object.get(user=request_user)
```
would fail because `request_user` is a Django `AnonymousUser` instance, and not a Django `User` instance. You would have to write this query as:
```python
SomeModel.object.get(user_id=request_user.id)
```

This PR changes this behaviour by introducing a stateless JWT auth mechanism that returns a custom `TokenUser` object which can be used for querying relations just like the Django `User`